### PR TITLE
más preguntas SIRE y try-catch en mooviScraper

### DIFF
--- a/SIRE/Unit1.json
+++ b/SIRE/Unit1.json
@@ -24,12 +24,7 @@
     },
     {
       "question": "Un estudiante está implementando un programa en Lustre para detectar flancos de subida y bajada en una señal booleana. ¿Qué función debería usar para detectar un flanco de subida?",
-      "options": [
-        "EDGE(X)",
-        "R_EDGE(X)",
-        "pre(X)",
-        "X and Y"
-      ],
+      "options": ["EDGE(X)", "R_EDGE(X)", "pre(X)", "X and Y"],
       "correct_option": 1,
       "questionType": "singleChoice"
     },
@@ -178,12 +173,7 @@
     },
     {
       "question": "Un estudiante quiere visualizar el comportamiento de un programa Lustre en tiempo real. ¿Qué herramienta debería usar?",
-      "options": [
-        "VirtualBox",
-        "Luciole",
-        "Gedit",
-        "Lustre"
-      ],
+      "options": ["VirtualBox", "Luciole", "Gedit", "Lustre"],
       "correct_option": 1,
       "questionType": "singleChoice"
     },
@@ -233,23 +223,13 @@
     },
     {
       "question": "Un estudiante está implementando un nodo en Lustre para detectar flancos de subida en una señal booleana. ¿Qué operador debería usar para comparar el valor actual con el valor anterior de la señal?",
-      "options": [
-        "X and Y",
-        "pre(X)",
-        "X or Y",
-        "not(X)"
-      ],
+      "options": ["X and Y", "pre(X)", "X or Y", "not(X)"],
       "correct_option": 1,
       "questionType": "singleChoice"
     },
     {
       "question": "Un sistema de detección de eventos debe identificar transiciones de un botón de apagado/encendido. ¿Qué nodo de Lustre se debe utilizar?",
-      "options": [
-        "EDGE",
-        "ABRO",
-        "MOUSE",
-        "COUNTER"
-      ],
+      "options": ["EDGE", "ABRO", "MOUSE", "COUNTER"],
       "correct_option": 0,
       "questionType": "singleChoice"
     },

--- a/SIRE/Unit1.json
+++ b/SIRE/Unit1.json
@@ -24,7 +24,12 @@
     },
     {
       "question": "Un estudiante está implementando un programa en Lustre para detectar flancos de subida y bajada en una señal booleana. ¿Qué función debería usar para detectar un flanco de subida?",
-      "options": ["EDGE(X)", "R_EDGE(X)", "pre(X)", "X and Y"],
+      "options": [
+        "EDGE(X)",
+        "R_EDGE(X)",
+        "pre(X)",
+        "X and Y"
+      ],
       "correct_option": 1,
       "questionType": "singleChoice"
     },
@@ -173,7 +178,12 @@
     },
     {
       "question": "Un estudiante quiere visualizar el comportamiento de un programa Lustre en tiempo real. ¿Qué herramienta debería usar?",
-      "options": ["VirtualBox", "Luciole", "Gedit", "Lustre"],
+      "options": [
+        "VirtualBox",
+        "Luciole",
+        "Gedit",
+        "Lustre"
+      ],
       "correct_option": 1,
       "questionType": "singleChoice"
     },
@@ -234,13 +244,23 @@
     },
     {
       "question": "Un estudiante está implementando un nodo en Lustre para detectar flancos de subida en una señal booleana. ¿Qué operador debería usar para comparar el valor actual con el valor anterior de la señal?",
-      "options": ["X and Y", "pre(X)", "X or Y", "not(X)"],
+      "options": [
+        "X and Y",
+        "pre(X)",
+        "X or Y",
+        "not(X)"
+      ],
       "correct_option": 1,
       "questionType": "singleChoice"
     },
     {
       "question": "Un sistema de detección de eventos debe identificar transiciones de un botón de apagado/encendido. ¿Qué nodo de Lustre se debe utilizar?",
-      "options": ["EDGE", "ABRO", "MOUSE", "COUNTER"],
+      "options": [
+        "EDGE",
+        "ABRO",
+        "MOUSE",
+        "COUNTER"
+      ],
       "correct_option": 0,
       "questionType": "singleChoice"
     },
@@ -286,6 +306,39 @@
         "Ejecutar el código con la opción `-exec`."
       ],
       "correct_option": 0,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "Después de compilar `abro.lus`, ¿cómo se ejecuta la simulación en terminal?",
+      "options": [
+        "`lv6 abro.lus c-exec`",
+        "`lv6 abro.lus -sim`",
+        "`luciole abro.lus ABRO`",
+        "`./ABRO.exec`"
+      ],
+      "correct_option": 3,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "Un estudiante modifica el código de `edge.lus`, cambiando la línea que define la salida `Y` en el nodo `EDGE` de:\nY = R_EDGE(X) or R_EDGE(not(X));\na:\nY = R_EDGE(X) and R_EDGE(not(X));\n¿Qué consecuencia tendrá este cambio en el comportamiento del sistema?",
+      "options": [
+        "El sistema solo detectará flancos cuando tanto `X` como `not(X)` tengan un flanco en el mismo ciclo, lo que es imposible, por lo que `Y` siempre será falso.",
+        "El sistema generará un error de compilación debido a la incompatibilidad de operadores.",
+        "El sistema detectará flancos de subida y bajada de manera más eficiente.",
+        "El sistema detectará flancos de subida y bajada correctamente, pero con un retraso de un ciclo."
+      ],
+      "correct_option": 0,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "¿Qué ocurre cuando un sistema reactivo permite preempción?",
+      "options": [
+        "Se reduce el consumo de CPU.",
+        "Todas las tareas se ejecutan en orden de llegada.",
+        "No hay interrupciones durante la ejecución.",
+        "Tareas de menor prioridad pueden ser interrumpidas por tareas urgentes."
+      ],
+      "correct_option": 3,
       "questionType": "singleChoice"
     }
   ]

--- a/SIRE/Unit1.json
+++ b/SIRE/Unit1.json
@@ -210,17 +210,6 @@
       "questionType": "singleChoice"
     },
     {
-      "question": "Un estudiante modifica el código de `edge.lus`, cambiando la línea que define la salida `Y` en el nodo `EDGE` de:<br><br> Y = R_EDGE(X) or R_EDGE(not(X));<br><br>a:<br><br>  Y = R_EDGE(X) and R_EDGE(not(X));<br><br>¿Qué consecuencia tendrá este cambio en el comportamiento del sistema?",
-      "options": [
-        "El sistema generará un error de compilación debido a la incompatibilidad de operadores.",
-        "El sistema solo detectará flancos cuando tanto `X` como `not(X)` tengan un flanco en el mismo ciclo, lo que es imposible, por lo que `Y` siempre será falso.",
-        "El sistema detectará flancos de subida y bajada correctamente, pero con un retraso de un ciclo.",
-        "El sistema detectará flancos de subida y bajada de manera más eficiente."
-      ],
-      "correct_option": 1,
-      "questionType": "singleChoice"
-    },
-    {
       "question": "Un estudiante implementa la especificación ABRO pero olvida incluir la señal `R` en la reinicialización del sistema. ¿Qué consecuencia es más probable?",
       "options": [
         "El programa generará un error de sintaxis.",

--- a/SIRE/Unit2.json
+++ b/SIRE/Unit2.json
@@ -2,13 +2,7 @@
   "questions": [
     {
       "question": "En el código Lustre TrafficLight2, si Fase es 0 y el botón no se presiona, ¿qué estado muestra el semáforo?",
-      "options": [
-        "GREEN",
-        "WALK",
-        "YELLOW",
-        "RED",
-        "DONTWALK"
-      ],
+      "options": ["GREEN", "WALK", "YELLOW", "RED", "DONTWALK"],
       "correct_option": 0,
       "questionType": "singleChoice"
     },

--- a/SIRE/Unit2.json
+++ b/SIRE/Unit2.json
@@ -2,7 +2,13 @@
   "questions": [
     {
       "question": "En el código Lustre TrafficLight2, si Fase es 0 y el botón no se presiona, ¿qué estado muestra el semáforo?",
-      "options": ["GREEN", "WALK", "YELLOW", "RED", "DONTWALK"],
+      "options": [
+        "GREEN",
+        "WALK",
+        "YELLOW",
+        "RED",
+        "DONTWALK"
+      ],
       "correct_option": 0,
       "questionType": "singleChoice"
     },
@@ -68,6 +74,94 @@
         "Cuando Fase es 4.",
         "Cuando Fase toma el valor 1.",
         "Cuando BOTON es presionado."
+      ],
+      "correct_option": 0,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "En el código Lustre TrafficLight, ¿qué función cumple la expresión `pre(Fase)`?",
+      "options": [
+        "Reinicia Fase a 0 en cada ciclo.",
+        "Indica la fase previa del semáforo de forma constante.",
+        "Inicializa Fase con un valor predefinido.",
+        "Almacena el valor anterior de Fase para utilizarlo en el siguiente ciclo."
+      ],
+      "correct_option": 3,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "¿Cómo se relaciona el formato RIF con el lenguaje Lustre?",
+      "options": [
+        "RIF se usa como un formato de intercambio de datos entre Lustre y simulaciones.",
+        "RIF transforma código Lustre en un modelo gráfico de simulación.",
+        "RIF es un lenguaje de programación alternativo a Lustre.",
+        "RIF es un compilador de Lustre para ejecución en hardware."
+      ],
+      "correct_option": 0,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "Pregunta 33:\nEn el nodo TrafficLight, ¿cuál es la fase en la que los peatones pueden cruzar?",
+      "options": [
+        "Fase 0 (verde para vehículos).",
+        "Fase 1 (amarillo para vehículos).",
+        "Fase 4 (rojo para vehículos y peatones deben prepararse para detenerse).",
+        "Fase 3 (rojo para vehículos y peatones pueden caminar)."
+      ],
+      "correct_option": 3,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "3. Near-miss multiple choice\nPregunta 5:\nEn el nodo TrafficLight, si el botón (BOTON) se presiona en la fase 4 (rojo y peatones deben prepararse para detenerse), ¿qué ocurre?",
+      "options": [
+        "El semáforo se apaga.",
+        "El semáforo avanza a la fase 5.",
+        "El semáforo permanece en la fase 4.",
+        "El semáforo regresa a la fase 0 (verde)."
+      ],
+      "correct_option": 3,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "Según el código Lustre TrafficLight, ¿qué ocurre si BOTON no es presionado y Fase es igual a 0?",
+      "options": [
+        "El semáforo pasa a amarillo.",
+        "El semáforo sigue en verde.",
+        "El semáforo pasa a rojo.",
+        "La señal WALK se enciende."
+      ],
+      "correct_option": 1,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "¿Cuál es el propósito de `pre(Fase)` en el código Lustre TrafficLight?",
+      "options": [
+        "Guardar el valor anterior de Fase para usarlo en el siguiente ciclo.",
+        "Mantener un registro constante de la fase previa del semáforo.",
+        "Reiniciar Fase a 0 en cada iteración.",
+        "Inicializar Fase con un valor predefinido."
+      ],
+      "correct_option": 0,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "¿Cuál es la condición en el código Lustre TrafficLight para que la señal WALK se active?",
+      "options": [
+        "Cuando Fase toma el valor 3.",
+        "Cuando Fase es igual a 1.",
+        "Cuando BOTON se mantiene presionado.",
+        "Cuando Fase alcanza 4."
+      ],
+      "correct_option": 0,
+      "questionType": "singleChoice"
+    },
+    {
+      "question": "En el código Lustre TrafficLight2, ¿cuál es la condición para que Fase tome el valor 1?",
+      "options": [
+        "BOTON es verdadero y la señal DONTWALK era verdadera en el ciclo anterior.",
+        "Fase es mayor que 2.",
+        "BOTON es verdadero en cualquier momento.",
+        "Fase es igual a 4."
       ],
       "correct_option": 0,
       "questionType": "singleChoice"

--- a/UTILS/scrapingUtils/mooviScraper.py
+++ b/UTILS/scrapingUtils/mooviScraper.py
@@ -71,7 +71,7 @@ def format_into_json(questions, answers, type, correct, filepath=None) -> dict:
     for q, a, t, c in zip(questions, answers, type, correct):
         if t == 2:
             try:
-                correct_option = c[0] if isinstance(c, list) else c,
+                correct_option = (c[0] if isinstance(c, list) else c,)
             except IndexError:
                 correct_option = -1
             type = "singleChoice"
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         view-source:https://moovi.uvigo.gal/mod/quiz/review.php...
     Dalle a Ctrl+A para seleccionalo todo, cópiao e pégao nun arquivo html no directorio no que o vaias ler.
     En firefox está comprobado que funciona.
-    
+
     Después de ejecutar, revisad el JSON. Modificad a mano los -1 que encontréis en correct_option.
     """
 

--- a/UTILS/scrapingUtils/mooviScraper.py
+++ b/UTILS/scrapingUtils/mooviScraper.py
@@ -70,11 +70,15 @@ def format_into_json(questions, answers, type, correct, filepath=None) -> dict:
 
     for q, a, t, c in zip(questions, answers, type, correct):
         if t == 2:
+            try:
+                correct_option = c[0] if isinstance(c, list) else c,
+            except IndexError:
+                correct_option = -1
             type = "singleChoice"
             dict_q = {
                 "question": q,
                 "options": a,
-                "correct_option": c[0] if isinstance(c, list) else c,
+                "correct_option": correct_option,
                 "questionType": type,
             }
         elif t == 4:
@@ -100,10 +104,13 @@ if __name__ == "__main__":
     No seu lugar, unha vez no exame escribe na barra de busca 'view-source' ao principio da query:
         view-source:https://moovi.uvigo.gal/mod/quiz/review.php...
     Dalle a Ctrl+A para seleccionalo todo, cópiao e pégao nun arquivo html no directorio no que o vaias ler.
-    En firefox está comprobado que funciona."""
+    En firefox está comprobado que funciona.
+    
+    Después de ejecutar, revisad el JSON. Modificad a mano los -1 que encontréis en correct_option.
+    """
 
     path = "moovi.html"
-    newfile_name = "prueba.json"
+    newfile_name = "new.json"
     data = get_moovi_data(use_file=path)
 
     # Example usage


### PR DESCRIPTION
El mooviScraper no da pillado las opciones correctas de algunos cuestionarios. Para solucionarlo, coloca un -1 como opción correcta y sigue con la ejecución.